### PR TITLE
feat: add prometheus listener

### DIFF
--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -40,12 +40,13 @@ import (
 )
 
 const (
-	OctaviaFeatureTags              = 0
-	OctaviaFeatureVIPACL            = 1
-	OctaviaFeatureFlavors           = 2
-	OctaviaFeatureTimeout           = 3
-	OctaviaFeatureAvailabilityZones = 4
-	OctaviaFeatureHTTPMonitorsOnUDP = 5
+	OctaviaFeatureTags               = 0
+	OctaviaFeatureVIPACL             = 1
+	OctaviaFeatureFlavors            = 2
+	OctaviaFeatureTimeout            = 3
+	OctaviaFeatureAvailabilityZones  = 4
+	OctaviaFeatureHTTPMonitorsOnUDP  = 5
+	OctaviaFeaturePrometheusListener = 6
 
 	waitLoadbalancerInitDelay   = 1 * time.Second
 	waitLoadbalancerFactor      = 1.2
@@ -143,6 +144,14 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int, l
 		}
 		verHTTPMonitorsOnUDP, _ := version.NewVersion("v2.16")
 		if currentVer.GreaterThanOrEqual(verHTTPMonitorsOnUDP) {
+			return true
+		}
+	case OctaviaFeaturePrometheusListener:
+		if lbProvider == "ovn" {
+			return false
+		}
+		verACL, _ := version.NewVersion("v2.25")
+		if currentVer.GreaterThanOrEqual(verACL) {
 			return true
 		}
 	default:


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
